### PR TITLE
5.5.3

### DIFF
--- a/packages/browser-extension/src/manifest.json
+++ b/packages/browser-extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Cookie Dialog Monster",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "default_locale": "en",
   "description": "__MSG_appDesc__",
   "icons": {

--- a/packages/browser-extension/src/scripts/background.js
+++ b/packages/browser-extension/src/scripts/background.js
@@ -57,13 +57,13 @@ const enableIcon = (tabId) =>
 const enablePopup = (tabId) => chrome.browserAction.setPopup({ popup: 'popup.html', tabId });
 
 /**
- * @description Retrieves cache state
+ * @description Retrieves store
  * @param {string} hostname
  * @param {void} callback
  * @returns {{ enabled: boolean }}
  */
 
-const getCache = (hostname, callback) => {
+const getStore = (hostname, callback) => {
   chrome.storage.local.get(null, (store) => {
     callback(store[hostname] ?? initial);
   });
@@ -178,12 +178,12 @@ const report = () => {
 };
 
 /**
- * @description Update cache state
+ * @description Update store
  * @param {string} [hostname]
  * @param {object} [state]
  */
 
-const updateCache = (hostname, state) => {
+const updateStore = (hostname, state) => {
   chrome.storage.local.get(null, (cache) => {
     const current = cache[hostname];
 
@@ -214,17 +214,17 @@ chrome.runtime.onMessage.addListener((request, sender, callback) => {
     case 'ENABLE_POPUP':
       if (tabId) enablePopup(tabId);
       break;
-    case 'GET_CACHE':
-      getCache(hostname, callback);
-      break;
     case 'GET_DATA':
       getData(callback);
+      break;
+    case 'GET_STORE':
+      getStore(hostname, callback);
       break;
     case 'GET_TAB':
       getTab(callback);
       break;
-    case 'UPDATE_CACHE':
-      updateCache(hostname, state);
+    case 'UPDATE_STORE':
+      updateStore(hostname, state);
       break;
     default:
       break;
@@ -239,6 +239,7 @@ chrome.runtime.onMessage.addListener((request, sender, callback) => {
 
 chrome.contextMenus.create({
   contexts: ['all'],
+  documentUrlPatterns: chrome.runtime.getManifest().content_scripts[0].matches,
   id: contextMenuId,
   title: chrome.i18n.getMessage('contextMenuText'),
 });

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -33,17 +33,17 @@ const fixes = [];
 const hostname = document.location.hostname.split('.').slice(-2).join('.');
 
 /**
- * @description Is consent preview page?
- */
-
-const preview = hostname.startsWith('consent.') || hostname.startsWith('myprivacy.');
-
-/**
  * @description Options provided to observer
  * @type {MutationObserverInit}
  */
 
-const options = { attributes: true, childList: true, subtree: true };
+const options = { childList: true, subtree: true };
+
+/**
+ * @description Is consent preview page?
+ */
+
+const preview = hostname.startsWith('consent.') || hostname.startsWith('myprivacy.');
 
 /**
  * @description Selectors list
@@ -139,19 +139,6 @@ const observer = new MutationObserver((mutations, instance) => {
 });
 
 /**
- * @description Gets data
- * @returns {Promise<any[]>}
- */
-
-const promiseAll = () =>
-  Promise.all([
-    new Promise((resolve) => dispatch({ type: 'GET_CLASSES' }, null, resolve)),
-    new Promise((resolve) => dispatch({ type: 'GET_FIXES' }, null, resolve)),
-    new Promise((resolve) => dispatch({ type: 'GET_SELECTORS' }, null, resolve)),
-    new Promise((resolve) => dispatch({ type: 'GET_SKIPS' }, null, resolve)),
-  ]);
-
-/**
  * @description Cleans DOM again after all
  * @listens document#readystatechange
  */
@@ -179,17 +166,18 @@ window.addEventListener('unload', () => {});
  * @description Setups everything and starts to observe if enabled
  */
 
-dispatch({ hostname, type: 'GET_CACHE' }, null, async ({ enabled }) => {
+dispatch({ hostname, type: 'GET_CACHE' }, null, ({ enabled }) => {
   dispatch({ type: 'ENABLE_POPUP' });
 
   if (enabled) {
-    const results = await promiseAll();
-
-    classes.push(...(results[0]?.classes ?? []));
-    fixes.push(...(results[1]?.fixes ?? []));
-    selectors.push(...(results[2]?.elements ?? []));
-    skips.push(...(results[3]?.skips ?? []));
-    observer.observe(target, options);
-    dispatch({ type: 'ENABLE_ICON' });
+    dispatch({ type: 'GET_DATA' }, null, (data) => {
+      classes.push(...data.classes);
+      fixes.push(...data.fixes);
+      options.attributeFilter = data.attributes;
+      selectors.push(...data.selectors);
+      skips.push(...data.skips);
+      observer.observe(target, options);
+      dispatch({ type: 'ENABLE_ICON' });
+    });
   }
 });

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -61,23 +61,26 @@ const target = document.body || document.documentElement;
 /**
  * @description Checks if node element is removable
  * @param {any} node
+ * @param {boolean} skipMatch
  * @returns {boolean}
  */
 
-const check = (node) =>
+const check = (node, skipMatch) =>
   node instanceof HTMLElement &&
   node.parentElement &&
   !['BODY', 'HTML'].includes(node.tagName) &&
   !(node.id && ['APP', 'ROOT'].includes(node.id.toUpperCase?.())) &&
-  node.matches(selectors);
+  (skipMatch || node.matches(selectors));
 
 /**
  * @description Cleans DOM
  * @param {HTMLElement[]} nodes
+ * @param {boolean} skipMatch
  * @returns {void}
  */
 
-const clean = (nodes) => nodes.filter(check).forEach((node) => (node.outerHTML = ''));
+const clean = (nodes, skipMatch) =>
+  nodes.filter((node) => check(node, skipMatch)).forEach((node) => (node.outerHTML = ''));
 
 /**
  * @description Fixes scroll issues
@@ -149,8 +152,8 @@ document.addEventListener('readystatechange', () => {
       const nodes = selectors.length ? Array.from(document.querySelectorAll(selectors)) : [];
 
       fix();
-      clean(nodes);
-      setTimeout(() => clean(nodes), 2000);
+      clean(nodes, true);
+      setTimeout(() => clean(nodes, true), 2000);
     }
   });
 });

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -147,7 +147,7 @@ const observer = new MutationObserver((mutations, instance) => {
  */
 
 document.addEventListener('readystatechange', () => {
-  dispatch({ hostname, type: 'GET_CACHE' }, null, async ({ enabled }) => {
+  dispatch({ hostname, type: 'GET_STORE' }, null, async ({ enabled }) => {
     if (document.readyState === 'complete' && enabled && !preview) {
       const nodes = selectors.length ? Array.from(document.querySelectorAll(selectors)) : [];
 
@@ -169,7 +169,7 @@ window.addEventListener('unload', () => {});
  * @description Setups everything and starts to observe if enabled
  */
 
-dispatch({ hostname, type: 'GET_CACHE' }, null, ({ enabled }) => {
+dispatch({ hostname, type: 'GET_STORE' }, null, ({ enabled }) => {
   dispatch({ type: 'ENABLE_POPUP' });
 
   if (enabled) {

--- a/packages/browser-extension/src/scripts/popup.js
+++ b/packages/browser-extension/src/scripts/popup.js
@@ -36,14 +36,10 @@ const isChromium = chrome.runtime.getURL('').startsWith('chrome-extension://');
 
 const handlePowerChange = () => {
   dispatch({ type: 'GET_TAB' }, null, ({ hostname, id }) => {
-    dispatch({ hostname, type: 'GET_CACHE' }, null, ({ enabled }) => {
+    dispatch({ hostname, type: 'GET_STORE' }, null, ({ enabled }) => {
       const power = document.getElementById('power');
 
-      dispatch({
-        hostname,
-        state: { enabled: !enabled },
-        type: 'UPDATE_CACHE',
-      });
+      dispatch({ hostname, state: { enabled: !enabled }, type: 'UPDATE_STORE' });
       if (!enabled === false) power.removeAttribute('checked');
       if (!enabled === true) power.setAttribute('checked', 'checked');
       chrome.tabs.reload(id, { bypassCache: true });
@@ -90,7 +86,7 @@ const handleRate = (event) => {
 
 const handleContentLoaded = () => {
   dispatch({ type: 'GET_TAB' }, null, ({ hostname }) => {
-    dispatch({ hostname, type: 'GET_CACHE' }, null, ({ enabled }) => {
+    dispatch({ hostname, type: 'GET_STORE' }, null, ({ enabled }) => {
       translate();
 
       const host = document.getElementById('host');


### PR DESCRIPTION
## Description

- Add request cache to fetch them just one time.
- Filter pages that show the report option by content matches.
- Filter attributes by included in `elements.txt`.
- Minor code improvements.
- Stop matching already matched elements with `skipMatch`.

## Browsers

- [x] Google Chrome 51+.
- [x] Microsoft Edge 15+.
- [x] Mozilla Firefox 54+.
- [x] Opera 38+.