### PR TITLE
7.1.1

### DIFF
--- a/.commitlintrc
+++ b/.commitlintrc
@@ -20,6 +20,7 @@
         "database",
         "docs",
         "packages",
+        "rules",
         "web"
       ]
     ]

--- a/packages/browser-extension/src/manifest.json
+++ b/packages/browser-extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Cookie Dialog Monster",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "default_locale": "en",
   "description": "__MSG_appDesc__",
   "icons": {

--- a/packages/browser-extension/src/rules.json
+++ b/packages/browser-extension/src/rules.json
@@ -31,5 +31,16 @@
       "urlFilter": "||consent.trustarc.com^",
       "resourceTypes": ["script"]
     }
+  },
+  {
+    "id": 4,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "||wcpstatic.microsoft.com^",
+      "resourceTypes": ["script"]
+    }
   }
 ]

--- a/packages/browser-extension/src/rules.json
+++ b/packages/browser-extension/src/rules.json
@@ -6,6 +6,17 @@
       "type": "block"
     },
     "condition": {
+      "urlFilter": "||cdn.cookielaw.org^",
+      "resourceTypes": ["script"]
+    }
+  },
+  {
+    "id": 2,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
       "urlFilter": "||cmp.inmobi.com^",
       "resourceTypes": ["script"]
     }

--- a/packages/browser-extension/src/rules.json
+++ b/packages/browser-extension/src/rules.json
@@ -6,8 +6,8 @@
       "type": "block"
     },
     "condition": {
-      "urlFilter": "||cdn.cookielaw.org^",
-      "resourceTypes": ["script"]
+      "resourceTypes": ["script"],
+      "urlFilter": "||app.usercentrics.eu^"
     }
   },
   {
@@ -17,8 +17,8 @@
       "type": "block"
     },
     "condition": {
-      "urlFilter": "||cmp.inmobi.com^",
-      "resourceTypes": ["script"]
+      "resourceTypes": ["script"],
+      "urlFilter": "||cdn.cookielaw.org^"
     }
   },
   {
@@ -28,8 +28,8 @@
       "type": "block"
     },
     "condition": {
-      "urlFilter": "||consent.trustarc.com^",
-      "resourceTypes": ["script"]
+      "resourceTypes": ["script"],
+      "urlFilter": "||cmp.inmobi.com^"
     }
   },
   {
@@ -39,8 +39,19 @@
       "type": "block"
     },
     "condition": {
-      "urlFilter": "||wcpstatic.microsoft.com^",
-      "resourceTypes": ["script"]
+      "resourceTypes": ["script"],
+      "urlFilter": "||consent.trustarc.com^"
+    }
+  },
+  {
+    "id": 5,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "resourceTypes": ["script"],
+      "urlFilter": "||wcpstatic.microsoft.com^"
     }
   }
 ]

--- a/packages/browser-extension/src/rules.json
+++ b/packages/browser-extension/src/rules.json
@@ -6,7 +6,15 @@
       "type": "block"
     },
     "condition": {
-      "resourceTypes": ["script"],
+      "resourceTypes": [
+        "font",
+        "image",
+        "media",
+        "object",
+        "script",
+        "stylesheet",
+        "xmlhttprequest"
+      ],
       "urlFilter": "||app.usercentrics.eu^"
     }
   },
@@ -17,7 +25,15 @@
       "type": "block"
     },
     "condition": {
-      "resourceTypes": ["script"],
+      "resourceTypes": [
+        "font",
+        "image",
+        "media",
+        "object",
+        "script",
+        "stylesheet",
+        "xmlhttprequest"
+      ],
       "urlFilter": "||c.evidon.com^"
     }
   },
@@ -28,7 +44,15 @@
       "type": "block"
     },
     "condition": {
-      "resourceTypes": ["script"],
+      "resourceTypes": [
+        "font",
+        "image",
+        "media",
+        "object",
+        "script",
+        "stylesheet",
+        "xmlhttprequest"
+      ],
       "urlFilter": "||cdn.cookielaw.org^"
     }
   },
@@ -39,7 +63,15 @@
       "type": "block"
     },
     "condition": {
-      "resourceTypes": ["script"],
+      "resourceTypes": [
+        "font",
+        "image",
+        "media",
+        "object",
+        "script",
+        "stylesheet",
+        "xmlhttprequest"
+      ],
       "urlFilter": "||cmp.inmobi.com^"
     }
   },
@@ -50,7 +82,15 @@
       "type": "block"
     },
     "condition": {
-      "resourceTypes": ["script"],
+      "resourceTypes": [
+        "font",
+        "image",
+        "media",
+        "object",
+        "script",
+        "stylesheet",
+        "xmlhttprequest"
+      ],
       "urlFilter": "||consent.trustarc.com^"
     }
   },
@@ -61,7 +101,34 @@
       "type": "block"
     },
     "condition": {
-      "resourceTypes": ["script"],
+      "resourceTypes": [
+        "font",
+        "image",
+        "media",
+        "object",
+        "script",
+        "stylesheet",
+        "xmlhttprequest"
+      ],
+      "urlFilter": "||optanon.blob.core.windows.net^"
+    }
+  },
+  {
+    "id": 7,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "resourceTypes": [
+        "font",
+        "image",
+        "media",
+        "object",
+        "script",
+        "stylesheet",
+        "xmlhttprequest"
+      ],
       "urlFilter": "||wcpstatic.microsoft.com^"
     }
   }

--- a/packages/browser-extension/src/rules.json
+++ b/packages/browser-extension/src/rules.json
@@ -18,7 +18,7 @@
     },
     "condition": {
       "resourceTypes": ["script"],
-      "urlFilter": "||cdn.cookielaw.org^"
+      "urlFilter": "||c.evidon.com^"
     }
   },
   {
@@ -29,7 +29,7 @@
     },
     "condition": {
       "resourceTypes": ["script"],
-      "urlFilter": "||cmp.inmobi.com^"
+      "urlFilter": "||cdn.cookielaw.org^"
     }
   },
   {
@@ -40,11 +40,22 @@
     },
     "condition": {
       "resourceTypes": ["script"],
-      "urlFilter": "||consent.trustarc.com^"
+      "urlFilter": "||cmp.inmobi.com^"
     }
   },
   {
     "id": 5,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "resourceTypes": ["script"],
+      "urlFilter": "||consent.trustarc.com^"
+    }
+  },
+  {
+    "id": 6,
     "priority": 1,
     "action": {
       "type": "block"

--- a/packages/browser-extension/src/rules.json
+++ b/packages/browser-extension/src/rules.json
@@ -20,5 +20,16 @@
       "urlFilter": "||cmp.inmobi.com^",
       "resourceTypes": ["script"]
     }
+  },
+  {
+    "id": 3,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "||consent.trustarc.com^",
+      "resourceTypes": ["script"]
+    }
   }
 ]

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -321,19 +321,6 @@ function fix() {
 }
 
 /**
- * @description Calculate reading time for the current page to avoid lags in large pages
- * @returns {number}
- */
-function readingTime() {
-  const text = document.body.innerText;
-  const wpm = 225;
-  const words = text.trim().split(/\s+/).length;
-  const time = Math.ceil(words / wpm);
-
-  return time;
-}
-
-/**
  * @description Restore DOM to its previous state
  * @returns {void}
  */
@@ -468,12 +455,18 @@ window.addEventListener(triggerEventName, (event) => {
     if (event.detail?.elements) {
       clean(event.detail.elements, event.detail.skipMatch);
     } else {
-      if (readingTime() < 4) {
-        forceClean(document.body);
-      } else {
-        // 2023-06-13: look into the first level of the document body, there are dialogs there very often
-        clean([...document.body.children]);
-      }
+      // 2024-08-03: look into the first level of important nodes, there are dialogs there very often
+      clean([
+        ...document.body.children,
+        ...Array.from(document.getElementsByClassName('container')[0]?.children ?? []),
+        ...Array.from(document.getElementsByClassName('layout')[0]?.children ?? []),
+        ...Array.from(document.getElementsByClassName('page')[0]?.children ?? []),
+        ...Array.from(document.getElementsByClassName('wrapper')[0]?.children ?? []),
+        ...Array.from(document.getElementById('__next')?.children ?? []),
+        ...Array.from(document.getElementById('app')?.children ?? []),
+        ...Array.from(document.getElementById('main')?.children ?? []),
+        ...Array.from(document.getElementById('root')?.children ?? []),
+      ]);
     }
   }
 });

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -273,7 +273,11 @@ function match(element, skipMatch) {
  * @returns {void}
  */
 function fix() {
-  const backdrops = document.querySelectorAll('.modal-backdrop, .overlay');
+  const backdrops = document.querySelectorAll([
+    '.modal-backdrop',
+    '.offcanvas-backdrop',
+    '.overlay',
+  ]);
   const domains = (skips?.domains ?? []).map((x) => (x.split('.').length < 3 ? `*${x}` : x));
 
   for (const backdrop of backdrops) {

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -191,13 +191,16 @@ function getHostname() {
  * @returns {boolean}
  */
 function isInViewport(element) {
+  const styles = window.getComputedStyle(element);
   const height = window.innerHeight || document.documentElement.clientHeight;
   const position = element.getBoundingClientRect();
   const scroll = window.scrollY;
+  const transitioning = styles.transitionDuration !== '0s';
 
   return (
     position.bottom === position.top ||
-    (scroll + position.top <= scroll + height && scroll + position.bottom >= scroll)
+    (scroll + position.top <= scroll + height && scroll + position.bottom >= scroll) ||
+    transitioning
   );
 }
 

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -270,7 +270,7 @@ function match(element, skipMatch) {
  * @returns {void}
  */
 function fix() {
-  const backdrops = document.getElementsByClassName('modal-backdrop');
+  const backdrops = document.querySelectorAll('.modal-backdrop, .overlay');
   const domains = (skips?.domains ?? []).map((x) => (x.split('.').length < 3 ? `*${x}` : x));
 
   for (const backdrop of backdrops) {

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -66,7 +66,10 @@ const options = { childList: true, subtree: true };
 /**
  * @description Is consent preview page?
  */
-const preview = hostname.startsWith('consent.') || hostname.startsWith('myprivacy.');
+const preview =
+  (hostname.startsWith('consent.') &&
+    !(hostname.startsWith('consent.google') || hostname.startsWith('consent.youtube'))) ||
+  hostname.startsWith('myprivacy.');
 
 /**
  * @description Elements that were already matched and are removable

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -235,7 +235,9 @@ function match(element, skipMatch) {
     return false;
   }
 
-  if (element.hasAttributes()) {
+  const hasAttributes = !!element.getAttributeNames().filter((x) => x !== 'data-nosnippet').length;
+
+  if (hasAttributes) {
     // 2023-06-10: fix #113 temporarily
     if (element.classList.contains('chat-line__message')) {
       return false;

--- a/packages/browser-extension/src/scripts/content.js
+++ b/packages/browser-extension/src/scripts/content.js
@@ -483,6 +483,5 @@ window.addEventListener('visibilitychange', async () => {
   if (document.visibilityState === 'visible' && !initiallyVisible) {
     initiallyVisible = true;
     await run();
-    window.dispatchEvent(new CustomEvent(triggerEventName));
   }
 });


### PR DESCRIPTION
## Description

- [x] Add some new block rules (#656, #662, #664, #669, #672)
- [x] Bypass preview pages check if they are Google consent pages (#643, #686)
- [x] Drop reading time logic (❗) 
- [x] Fix case wasn't removing element while transitioning (#630)
- [x] Fix cases when container changes, but this container contains the dialog (#703)
- [x] Fix check if element has attributes filtering out `data-nosnippet` (#714)
- [x] Improve performance removing unnecessary events

## Browsers

- [x] Google Chrome 88+
- [x] Microsoft Edge 88+
- [x] Mozilla Firefox 85+